### PR TITLE
Chore/update import rules

### DIFF
--- a/import.js
+++ b/import.js
@@ -20,7 +20,7 @@ module.exports = {
     "import/no-named-as-default": "error",
     "import/no-named-as-default-member": "error",
     "import/no-named-default": "error",
-    "import/no-extraneous-dependencies": ["error", {"devDependencies": false, "optionalDependencies": false, "peerDependencies": false}],
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": true, "optionalDependencies": true, "peerDependencies": false}],
     "import/no-unassigned-import": "error",
     "import/no-unresolved": ["error", { "caseSensitive": true }],
     "import/no-webpack-loader-syntax": "error",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-neatcapital",
-  "version": "1.1.7",
+  "version": "2.0.0",
   "description": "ESLint configurations for Neat Capital Inc.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This change should allow `devDependencies` and `optionalDependencies` to be used. This will require a minor version bump.