### PR TITLE
enable object rest spread

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,10 @@ module.exports = {
   },
   "extends": "eslint:recommended",
   "parserOptions": {
-    "ecmaVersion": 2017
+    "ecmaVersion": 2017,
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true
+    }
   },
   "rules": {
     "array-bracket-spacing": "error",


### PR DESCRIPTION
I bumped the node version on server so that we could use object rest spread, but the linter is dying now. It looks like we just have to enable that feature in the config.

This will get a minor version bump.