### PR TITLE
add eslint-plugin-react-hooks and remove react/jsx-no-bind

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "optionalDependencies": {
     "eslint-plugin-mocha": ">= 5.3.0",
     "eslint-plugin-import": ">= 2.16.0",
-    "eslint-plugin-react": ">= 7.12.0"
+    "eslint-plugin-react": ">= 7.12.0",
+    "eslint-plugin-react-hooks": ">= 4.2.0"
   },
   "author": "Neat Capital Inc.",
   "license": "MIT",

--- a/react.js
+++ b/react.js
@@ -1,7 +1,10 @@
 'use strict';
 
 module.exports = {
-  "extends": ["plugin:react/recommended"],
+  "extends": [
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended"
+  ],
   "env": {
     "browser": true,
     "mocha": true,
@@ -20,7 +23,8 @@ module.exports = {
     "sourceType": "module"
   },
   "plugins": [
-    "react"
+    "react",
+    "react-hooks"
   ],
   "rules": {
     "jsx-quotes": ["error", "prefer-single"],
@@ -34,7 +38,6 @@ module.exports = {
     "react/jsx-indent": ["error", 2],
     "react/jsx-indent-props": ["error", 2],
     "react/jsx-key": "error",
-    "react/jsx-no-bind": ["error", { "ignoreRefs": true }],
     "react/jsx-no-literals": "off",
     "react/jsx-no-target-blank": "error",
     "react/jsx-pascal-case": "error",
@@ -48,11 +51,8 @@ module.exports = {
     "react/no-find-dom-node": "off",
     "react/no-multi-comp": "error",
     "react/no-unescaped-entities": "error",
-    "react/no-unused-prop-types": "error",
-    "react/prop-types": "error",
     "react/self-closing-comp": "error",
     "react/sort-comp": "error",
-    "react/sort-prop-types": ["warn", { "callbacksLast": true }],
     "react/style-prop-object": "error"
   },
   "settings": {


### PR DESCRIPTION
`eslint-plugin-react-hooks` adds two essential checks for using hooks.

`react/jsx-no-bind`:

I think  is a bad rule. There are situations where following this rule is worse for performance. To properly optimize react renders and reconciliation this rule is just annoying and gets in the way. 

`prop-types`:

I think it is best to just ditch these rules. With everything new being typescript these don't help. When dealing with legacy code some components have incomplete propTypes and instead of requiring them to be maintained we should just refactor the component to typescript.


Let me know what you think, happy to provide more context or talk through any disagreements!


----


Side note - it might also be good to add rules from `jsx-a11y`. Here are the ones [CRA uses](https://github.com/facebook/create-react-app/blob/master/packages/eslint-config-react-app/index.js#L260). I'm not sure how many violations there will be but I find them pretty helpful when making sure the html is accessible as it can be.